### PR TITLE
[pytimeloop] Use conda installed Python + install PyTimeloop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "src/timeloop"]
 	path = src/timeloop
 	url = https://github.com/NVlabs/timeloop.git
+[submodule "src/timeloop-python"]
+	path = src/timeloop-python
+	url = https://github.com/Accelergy-Project/timeloop-python.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,18 +107,6 @@ RUN apt-get update \
     && useradd -m -d /home/workspace -c "Workspace User Account" -s /usr/sbin/nologin -g workspace workspace \
     && if [ ! -d $BUILD_DIR ]; then mkdir $BUILD_DIR; fi
 
-# Add conda and python3.8
-WORKDIR $BIN_DIR
-
-RUN wget -O ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-    && chmod +x ~/miniconda.sh \
-    && ~/miniconda.sh -b -p $BIN_DIR/conda \
-    && rm ~/miniconda.sh
-
-ENV PATH=$BIN_DIR/conda/bin:$PATH
-
-RUN conda install -y python=3.8
-
 # Get tools built in other containers
 
 WORKDIR $BUILD_DIR
@@ -160,22 +148,34 @@ WORKDIR $BUILD_DIR
 
 COPY --from=builder  $BUILD_DIR/cacti $SHARE_DIR/accelergy/estimation_plug_ins/accelergy-cacti-plug-in/cacti
 
-RUN pip install setuptools \
-    && pip install wheel \
-    && pip install libconf \
-    && pip install numpy \
+RUN pip3 install setuptools \
+    && pip3 install wheel \
+    && pip3 install libconf \
+    && pip3 install numpy \
     && cd accelergy \
-    && pip install . \
+    && pip3 install . \
     && cd .. \
     && cd accelergy-aladdin-plug-in \
-    && pip install . \
+    && pip3 install . \
     && cd .. \
     && cd accelergy-cacti-plug-in \
-    && pip install . \
+    && pip3 install . \
     && chmod 777 $SHARE_DIR/accelergy/estimation_plug_ins/accelergy-cacti-plug-in/cacti \
     && cd .. \
     && cd accelergy-table-based-plug-ins \
-    && pip install .
+    && pip3 install .
+
+# Add conda and python3.8 (in conda)
+WORKDIR $BIN_DIR
+
+RUN wget -O ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    && chmod +x ~/miniconda.sh \
+    && ~/miniconda.sh -b -p $BIN_DIR/conda \
+    && rm ~/miniconda.sh
+
+ENV PATH=$BIN_DIR/conda/bin:$PATH
+
+RUN conda install -y python=3.8
 
 # PyTimeloop
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,6 +166,8 @@ RUN pip3 install setuptools \
     && pip3 install .
 
 # Add conda and python3.8 (in conda)
+# WARNING: Conda should be installed after Accelergy. Otherwise, some Accelergy
+# data files are not installed correctly.
 WORKDIR $BIN_DIR
 
 RUN wget -O ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ REPO    := accelergy-timeloop-infrastructure
 NAME    := ${USER}/${REPO}
 TAG     := $$(git log -1 --pretty=%h)
 IMG     := ${NAME}:${TAG}
-LATEST  := ${NAME}:latest
+LATEST  := ${NAME}:dev
 
 
 all:	build

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ REPO    := accelergy-timeloop-infrastructure
 NAME    := ${USER}/${REPO}
 TAG     := $$(git log -1 --pretty=%h)
 IMG     := ${NAME}:${TAG}
-LATEST  := ${NAME}:dev
+LATEST  := ${NAME}:latest
 
 
 all:	build

--- a/src/accelergy_default_config.yaml
+++ b/src/accelergy_default_config.yaml
@@ -1,4 +1,5 @@
 version: 0.3
+compound_components: []
 estimator_plug_ins:
   - /usr/local/share/accelergy/estimation_plug_ins
 primitive_components:


### PR DESCRIPTION
- Conda is now installed in this repo. Removes the need to reinstall Python packages in `timeloop-accelergy-pytorch`.
- PyTimeloop is installed for the conda installed Python.