### PR TITLE
Fix pytimeloop installation & Add ruamel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,7 +184,11 @@ RUN apt-get update \
     && rm -rf build \
     && TIMELOOP_INCLUDE_PATH=$BUILD_DIR/timeloop/include \
        TIMELOOP_LIB_PATH=$LIB_DIR \
-       python3 -m pip install -e .
+       python3 -m pip install .
+
+# Ruamel yaml
+RUN pip3 install ruamel.yaml
+
 
 # Set up entrypoint
 


### PR DESCRIPTION
1. Pytimeloop should be installed without -e pip flag to be imported correctly.
2. Add Ruamel.yaml into Dockerfile 