### PR TITLE
Fix make and pat issue in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -349,6 +349,15 @@ RUN wget -O islpy-2024.2.tar.gz https://github.com/inducer/islpy/archive/refs/ta
     && ./build-with-barvinok.sh /usr/local
 
 WORKDIR $BUILD_DIR
+
+# Fix cmake issue and the pat issue
+RUN \
+    cd timeloop-python \
+    && grep -Rl 'cmake_minimum_required' . \
+    | xargs sed -i 's/cmake_minimum_required[[:space:]]*(VERSION[[:space:]]*[0-9.]\+)/cmake_minimum_required(VERSION 3.5)/' \
+    && rm -rf /usr/local/src/timeloop/include/pat \
+    && cp -r /usr/local/src/timeloop/pat-public/src/pat /usr/local/src/timeloop/include/
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
                g++ \


### PR DESCRIPTION
Hi!

When working with @sbochem and @nandeeka on the [fusemax artifacts](https://github.com/FPSG-UIUC/micro24-fusemax-artifact) repo we noticed that there are some cmake and pat issues. Here is a quick fix, maybe you'll propose a cleaner one.
Thanks!
Flavien

EDIT: I tested the diff only on the commit used by the fusemax artifacts. I'm not certain if it works/is useful in the newer version of this repo. Without this fix, the Dockerfile does not build for fusemax artifacts.

EDIT2: there seems also to be an issue with the RUN just before.